### PR TITLE
BugFixOnTagFunction

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -34,6 +34,11 @@ class TagsController < ApplicationController
 
   private
 
+  def tag_params
+    params.require(:tag).permit(:name).merge(user_id: current_user.id)
+
+  end
+
   def set_tag_memos
     @memos = Tag.find(params[:id]).memos
   end


### PR DESCRIPTION
# what
TagsControllerの修正（Tags#create）
ストロングパラメータtag_paramsの再作成
# why
ストロングパラメータの記述が消失し、タグ登録ができなくなっていたため。