### PR TITLE
FixBugOnViewOfFolderTagTree

### DIFF
--- a/app/views/shared/_contents_right.html.haml
+++ b/app/views/shared/_contents_right.html.haml
@@ -13,16 +13,16 @@
             .wrapper__contents__right__ul__search-form__folder__list__icon
               = icon('fas',' fa-tags')
             = form.label tag.name, class:"wrapper__contents__right__ul__search-form__folder__list__name"
-      .wrapper__contents__right__ul__search-form__folder
-        = icon('fas',' fa-folder')
-        = "no folder"
-        - @tags_nofolder.each do |tag|
-          %li.wrapper__contents__right__ul__search-form__folder__list
-            = form.check_box :tag_ids, { multiple: true, include_hidden: false, class: "wrapper__contents__right__ul__search-form__folder__list__checkbox" }, tag.id
-            -# form.check_box :配列名, { 複数のチェックボックスをひとまとめに扱うか, uncheck時に0の自動取得を回避, class:"クラス名" }, "チェック時に取得する値"
-            .wrapper__contents__right__ul__search-form__folder__list__icon
-              = icon('fas',' fa-tags')
-            = form.label tag.name, class:"wrapper__contents__right__ul__search-form__folder__list__name"
+    .wrapper__contents__right__ul__search-form__folder
+      = icon('fas',' fa-folder')
+      = "no folder"
+      - @tags_nofolder.each do |tag|
+        %li.wrapper__contents__right__ul__search-form__folder__list
+          = form.check_box :tag_ids, { multiple: true, include_hidden: false, class: "wrapper__contents__right__ul__search-form__folder__list__checkbox" }, tag.id
+          -# form.check_box :配列名, { 複数のチェックボックスをひとまとめに扱うか, uncheck時に0の自動取得を回避, class:"クラス名" }, "チェック時に取得する値"
+          .wrapper__contents__right__ul__search-form__folder__list__icon
+            = icon('fas',' fa-tags')
+          = form.label tag.name, class:"wrapper__contents__right__ul__search-form__folder__list__name"
     = form.submit '検索', class: "wrapper__contents__right__ul__search-form__submit"
   .wrapper__contents__right__ul__bottom
     %br.wrapper__contents__right__ul__bottom__guide

--- a/app/views/shared/_folder_index.haml
+++ b/app/views/shared/_folder_index.haml
@@ -2,19 +2,19 @@
   .wrapper__contents__folder_index__ul__title
     = "タグリスト編集"
   .wrapper__contents__folder_index__ul__tree
-    - @user_folders.each do |user_folder|
-      .wrapper__contents__folder_index__ul__tree__folder
+    .wrapper__contents__folder_index__ul__tree__folder
+      - @user_folders.each do |user_folder|
         .wrapper__contents__folder_index__ul__tree__folder__list
           .wrapper__contents__folder_index__ul__tree__folder__list__icon
             = icon('fas',' fa-folder')
           = link_to user_folder.name,edit_folder_path(user_folder) , class: "wrapper__contents__folder_index__ul__tree__folder__list__name"
           -# = link_to icon('fas',' fa-trash-alt'), folder_path(user_folder),class: "wrapper__contents__folder_index__ul__tree__folder__list__delete", method: :delete
-      .wrapper__contents__folder_index__ul__tree__tag
-        - user_folder.tags.each do |tag|
-          %li.wrapper__contents__folder_index__ul__tree__tag__list
-            .wrapper__contents__folder_index__ul__tree__tag__list__icon
-              = icon('fas',' fa-tags')
-            = link_to tag.name,edit_tag_path(tag) , class: "wrapper__contents__folder_index__ul__tree__tag__list__name"
+        .wrapper__contents__folder_index__ul__tree__tag
+          - user_folder.tags.each do |tag|
+            %li.wrapper__contents__folder_index__ul__tree__tag__list
+              .wrapper__contents__folder_index__ul__tree__tag__list__icon
+                = icon('fas',' fa-tags')
+              = link_to tag.name,edit_tag_path(tag) , class: "wrapper__contents__folder_index__ul__tree__tag__list__name"
     .wrapper__contents__folder_index__ul__tree__folder
       .wrapper__contents__folder_index__ul__tree__folder__list
         .wrapper__contents__folder_index__ul__tree__folder__list__icon


### PR DESCRIPTION
# what
Fixed bug on view of folder-tag-tree.
# why
Because nesting of tags connected with no folders are incorrect.