### PR TITLE
FixBugWithCreatingUserDefaultData

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,9 +12,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # POST /resource
   def create
     super
-    Folder.create( name: 'DefaultFolder', user_id: current_user.id )
-    @default_folder = Folder.where(name: 'DefaultFolder').where(user_id: current_user.id)
-    Tag.create( name: 'Temporary', user_id: current_user.id, folder_id: @default_folder.ids[0] )
+    default_folder = Folder.create( name: 'DefaultFolder', user_id: current_user.id )
+    Tag.create( name: 'Temporary', user_id: current_user.id, folder_id: default_folder.id )
   end
 
   # GET /resource/edit

--- a/db/migrate/20200207072248_create_tags.rb
+++ b/db/migrate/20200207072248_create_tags.rb
@@ -2,7 +2,7 @@ class CreateTags < ActiveRecord::Migration[5.2]
   def change
     create_table :tags do |t|
       t.string :name, null: false
-      t.index :name, unique: true
+      # t.index :name, unique: true
       t.references :user, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2020_03_28_061112) do
     t.datetime "updated_at", null: false
     t.bigint "folder_id"
     t.index ["folder_id"], name: "index_tags_on_folder_id"
-    t.index ["name"], name: "index_tags_on_name", unique: true
     t.index ["user_id"], name: "index_tags_on_user_id"
   end
 


### PR DESCRIPTION
# what
Disabled index setting on tag_name column by fix migration file.
# why
Because default tag name will be duplicated when some users are registered.